### PR TITLE
Add special case for op PlayKubeDownLibpod

### DIFF
--- a/hack/swagger-check
+++ b/hack/swagger-check
@@ -320,6 +320,9 @@ sub operation_name {
     if ($action eq 'df') {
         $action = 'dataUsage';
     }
+    elsif ($action eq "delete" && $endpoint eq "/libpod/play/kube") {
+        $action = "KubeDown"
+    }
     # Grrrrrr, this one is annoying: some operations get an extra 'All'
     elsif ($action =~ /^(delete|get|stats)$/ && $endpoint !~ /\{/) {
         $action .= "All";


### PR DESCRIPTION
Heuristic for guessing swagger operation id too limited for
PlayKubeDownLibpod

Signed-off-by: Jhon Honce <jhonce@redhat.com>